### PR TITLE
No Pull Request Testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,6 @@
 name: 'build-test'
-on: # rebuild any PRs and main branch changes
-  pull_request:
+on:
   push:
-    branches:
-      - main
-      - releases/*
 
 jobs:
   build: # make sure build/ci work properly
@@ -42,5 +38,5 @@ jobs:
         uses: ./
         with:
           room: '!gwaqKjZRpCQkpkTVwh:matrix.org'
-          message: test
+          message: 'matrix-notification: success'
           token: ${{ secrets.MATRIX_TOKEN }}


### PR DESCRIPTION
This patch removes the `pull_request` trigger, since it will fail as we need a valid matrix token to send the test message.