### PR TITLE
Update to Node.js 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,5 +23,5 @@ inputs:
     description: If to install the matrix-msg binary
     default: false
 runs:
-  using: node16
+  using: node20
   main: dist/index.js


### PR DESCRIPTION
The action still used the deprecated Node.js 16. This patch switches to the current LTS (Node.js 30) instead.