### PR TITLE
Remove stale eslint dependency group from dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,3 @@ updates:
     directory: /
     schedule:
       interval: monthly
-    groups:
-      eslint:
-        patterns:
-          - "*eslint*"


### PR DESCRIPTION
ESLint and all *eslint* packages were replaced by Biome; this Dependabot group now matched nothing and was silent dead config.